### PR TITLE
Explicitly scope /tc/ in az names JSON call

### DIFF
--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -234,7 +234,7 @@
         xmlhttp.send();
       }
 
-      ajax_get('https://stacks.lib.umn.edu/lg/az/names.json', function(data) {
+      ajax_get('https://stacks.lib.umn.edu/lg/tc/az/names.json', function(data) {
         var html = "";
         for (var i=0; i < data.length; i++) {
           html += '<option label="' + data[i].replace(/"/g, '\\"') + '" value="' + data[i].replace(/"/g, '\\"') + '" />';


### PR DESCRIPTION
I should have remembered this from the beginning - the data source won't change but going forward I would like to keep an explicit `/tc/` scope in all our LibGuides API integration paths. So the two new endpoints should be a little different than I gave you before.

* https://stacks.lib.umn.edu/lg/tc/az/names.json
* https://stacks.lib.umn.edu/lg/tc/subjects/names.json